### PR TITLE
Get rid of visual matching

### DIFF
--- a/docs/docs/modules/clipboard.md
+++ b/docs/docs/modules/clipboard.md
@@ -78,17 +78,3 @@ var quill = new Quill('#editor', {
   }
 });
 ```
-
-### matchVisual
-
-Quill by default does not have padding or margin for each line, whereas some websites or sources where a paste will come from will. By default Quill will try to match this spacing visually by adding an extra line to compensate for the missing margin/padding. This option disables this behavior.
-
-```javascript
-var quill = new Quill('#editor', {
-  modules: {
-    clipboard: {
-      matchVisual: false
-    }
-  }
-});
-```

--- a/modules/clipboard.js
+++ b/modules/clipboard.js
@@ -24,7 +24,6 @@ const CLIPBOARD_CONFIG = [
   ['br', matchBreak],
   [Node.ELEMENT_NODE, matchNewline],
   [Node.ELEMENT_NODE, matchBlot],
-  [Node.ELEMENT_NODE, matchSpacing],
   [Node.ELEMENT_NODE, matchAttributor],
   [Node.ELEMENT_NODE, matchStyles],
   ['li', matchIndent],
@@ -63,7 +62,6 @@ class Clipboard extends Module {
     this.container.setAttribute('tabindex', -1);
     this.matchers = [];
     CLIPBOARD_CONFIG.concat(this.options.matchers).forEach(([selector, matcher]) => {
-      if (!options.matchVisual && matcher === matchSpacing) return;
       this.addMatcher(selector, matcher);
     });
   }
@@ -147,7 +145,7 @@ class Clipboard extends Module {
 }
 Clipboard.DEFAULTS = {
   matchers: [],
-  matchVisual: true
+  matchVisual: false
 };
 
 
@@ -296,16 +294,6 @@ function matchNewline(node, delta) {
   return delta;
 }
 
-function matchSpacing(node, delta) {
-  if (isLine(node) && node.nextElementSibling != null && !deltaEndsWith(delta, '\n\n')) {
-    let nodeHeight = node.offsetHeight + parseFloat(computeStyle(node).marginTop) + parseFloat(computeStyle(node).marginBottom);
-    if (node.nextElementSibling.offsetTop > node.offsetTop + nodeHeight*1.5) {
-      delta.insert('\n');
-    }
-  }
-  return delta;
-}
-
 function matchStyles(node, delta) {
   let formats = {};
   let style = node.style || {};
@@ -355,4 +343,4 @@ function matchText(node, delta) {
 }
 
 
-export { Clipboard as default, matchAttributor, matchBlot, matchNewline, matchSpacing, matchText };
+export { Clipboard as default, matchAttributor, matchBlot, matchNewline, matchText };


### PR DESCRIPTION
Remove `matchVisual` producing extra newlines insertions when using `clipboard.convert`.
Following the logic in https://github.com/quilljs/quill/commit/3897c981fcabc599ce3b90793a33d40c4fa25fee#diff-17d666047b36e1cb3223a2e3bce28780