### PR TITLE
fix: use setBaseAndExtent to workaround Safari 17 issue

### DIFF
--- a/core/shadow-selection-polyfill.js
+++ b/core/shadow-selection-polyfill.js
@@ -24,7 +24,7 @@ export class ShadowSelection {
     if (!processing) {
       let windowSel = window.getSelection();
       windowSel.removeAllRanges();
-      windowSel.addRange(range);
+      windowSel.setBaseAndExtent(range.startContainer, range.startOffset, range.endContainer, range.endOffset);
     }
   }
 


### PR DESCRIPTION
## Description

Based on https://github.com/quilljs/quill/issues/2021#issuecomment-1776007758

> `Selection.addRange` does not work in Safari in Native Shadow but can be replaced with `Selection.setBaseAndExtent`

## Type of change

- Bugfix