### PR TITLE
fix: add new emitter API to prevent memory leak

### DIFF
--- a/core/emitter.js
+++ b/core/emitter.js
@@ -19,13 +19,20 @@ class Emitter extends EventEmitter {
   constructor() {
     super();
     this.listeners = {};
-    EMITTERS.push(this);
     this.on('error', debug.error);
   }
 
   emit() {
     debug.log.apply(debug, arguments);
     super.emit.apply(this, arguments);
+  }
+
+  connect() {
+    EMITTERS.push(this);
+  }
+
+  disconnect() {
+    EMITTERS.splice(EMITTERS.indexOf(this), 1);
   }
 
   handleDOM(event, ...args) {


### PR DESCRIPTION
## Description

This is a better fix for https://github.com/vaadin/web-components/issues/6480. See the discussion in https://github.com/vaadin/web-components/pull/7547#discussion_r1679242029

Once this is merged, the `vaadin-rich-text-editor` should be updated to revert https://github.com/vaadin/web-components/pull/6506 so that we only initialize Quill in `ready()` and then just call `emitter.connect()` and `emitter.disconnect()` in corresponding lifecycle callbacks of the web component: `connectedCallback()` / `disconnectedCallback()`

Here's a comparison of the JS memory heap snapshots after calling `detach` / `reattach` for the `RichTextEditor` 20 times:

### Without a fix

Tested after just reverting thtps://github.com/vaadin/web-components/pull/6506 - note the emitters aren't GCed:

<img width="655" alt="Screenshot 2024-07-17 at 11 36 57" src="https://github.com/user-attachments/assets/84b78545-09d1-4d5f-82a7-bd5c5324a2b2">

### With a fix

While new web component is created on re-attach, calling `emitter.disconnect()` allows it to be GCed so there's only one:

<img width="654" alt="Screenshot 2024-07-17 at 11 39 00" src="https://github.com/user-attachments/assets/116af94c-2f55-447b-bb36-12cadb68e575">



## Type of change

- Bugfix